### PR TITLE
Switch download flow to local storage

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,8 +8,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.626.0",
-    "@aws-sdk/s3-request-presigner": "^3.626.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",

--- a/server/utils/s3.js
+++ b/server/utils/s3.js
@@ -1,32 +1,34 @@
-const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
-const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
+const fs = require("fs");
+const path = require("path");
 
-const getS3Client = () => {
-  if (!process.env.AWS_REGION || !process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
-    throw new Error("Missing AWS credentials environment variables");
+const resolveStorageRoot = () => path.resolve(__dirname, "..", "storage");
+
+const assertWithinStorage = (storageRoot, filePath) => {
+  const relativePath = path.relative(storageRoot, filePath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error("Invalid asset key path");
   }
+};
 
-  return new S3Client({
-    region: process.env.AWS_REGION,
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
-    }
-  });
+const ensureFileReadable = async (filePath) => {
+  await fs.promises.access(filePath, fs.constants.R_OK);
 };
 
 const createSignedDownloadUrl = async (key) => {
-  if (!process.env.AWS_BUCKET) {
-    throw new Error("Missing AWS_BUCKET environment variable");
+  if (!key) {
+    throw new Error("Missing asset key");
   }
 
-  const client = getS3Client();
-  const command = new GetObjectCommand({
-    Bucket: process.env.AWS_BUCKET,
-    Key: key
-  });
+  const storageRoot = resolveStorageRoot();
+  await fs.promises.mkdir(storageRoot, { recursive: true });
 
-  return getSignedUrl(client, command, { expiresIn: 900 });
+  const absolutePath = path.resolve(storageRoot, key);
+
+  assertWithinStorage(storageRoot, absolutePath);
+  await ensureFileReadable(absolutePath);
+
+  return absolutePath;
 };
 
 module.exports = {


### PR DESCRIPTION
## Summary
- replace the S3 download helper with a filesystem-based resolver that works with local storage
- serve download responses by streaming the file from disk instead of returning a pre-signed URL
- remove the unused AWS SDK dependencies and add a storage directory placeholder for bundled assets

## Testing
- npm test *(fails: missing Stripe dependency in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d87f3efcac83308c0d55ef451a1e7d